### PR TITLE
Fix code scanning alert no. 44: Client-side cross-site scripting

### DIFF
--- a/docs/Accueil_fichiers/37365a3758fb699d.runtime.js
+++ b/docs/Accueil_fichiers/37365a3758fb699d.runtime.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 (() => {
   "use strict";
   var e,
@@ -549,7 +551,7 @@
                 t("string" == typeof e ? { type: "error", target: {} } : e);
             };
             (n.onload = n.onerror = s),
-              (n.src = e),
+              (n.src = DOMPurify.sanitize(e)),
               (n.async = !1),
               (f = setTimeout(() => s({ type: "timeout", target: n }), r)),
               document.head.appendChild(n);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "portfolio": "file:../portfolio",
     "vue": "^3.4.29",
     "vue-router": "^4.3.3",
-    "vue-rss-feed": "^0.2.4"
+    "vue-rss-feed": "^0.2.4",
+    "dompurify": "^3.2.2"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.8.0",


### PR DESCRIPTION
Fixes [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/44](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/44)

To fix the problem, we need to ensure that the user input from `window.location.href` is properly sanitized before it is used to set the `src` attribute of the script element. One effective way to do this is by using a library like DOMPurify to sanitize the URL. This will help prevent any malicious scripts from being executed.

We will:
1. Import the DOMPurify library.
2. Use DOMPurify to sanitize the URL before assigning it to the `src` attribute of the script element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
