### PR TITLE
Fix code scanning alert no. 47: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "vue": "^3.4.29",
     "vue-router": "^4.3.3",
     "vue-rss-feed": "^0.2.4",
-    "dompurify": "^3.2.2"
+    "dompurify": "^3.2.2",
+    "he": "^1.2.0"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.8.0",

--- a/src/components/WelcomeItem.vue
+++ b/src/components/WelcomeItem.vue
@@ -2,6 +2,7 @@
 import { RouterLink } from 'vue-router'
 import { onMounted } from 'vue'
 import * as c from '../temp'
+import he from 'he'
 const log = c.default.setup()
 console.log(log)
 onMounted(() => {
@@ -15,7 +16,7 @@ onMounted(() => {
         item.href =
           item.href +
           'portfolio/projet/' +
-          item.textContent.split('/')[item.textContent.split('/').length - 1]
+          he.encode(item.textContent.split('/')[item.textContent.split('/').length - 1])
       }
 
       log.info(item.href)


### PR DESCRIPTION
Fixes [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/47](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/47)

To fix the problem, we need to ensure that the text content is properly sanitized before being used to construct the URL. This can be done by encoding the text content to escape any special characters that could be interpreted as HTML. We can use a library like `he` (HTML entities) to encode the text content safely.

1. Install the `he` library to handle HTML entity encoding.
2. Import the `he` library in the script.
3. Use the `he.encode` function to encode `item.textContent` before appending it to `item.href`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
