### PR TITLE
Potential fix for code scanning alert no. 123: Double escaping or unescaping

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -6678,7 +6678,7 @@
     };
   
     var pdfUnescape = function pdfUnescape(value) {
-      return value.replace(/\\\\/g, "\\").replace(/\\\(/g, "(").replace(/\\\)/g, ")");
+      return value.replace(/\\\(/g, "(").replace(/\\\)/g, ")").replace(/\\\\/g, "\\");
     };
   
     var f2 = function f2(number) {


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/123](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/123)

To fix the problem, we need to modify the `pdfUnescape` function to unescape the backslashes last. This ensures that any sequences involving backslashes are correctly handled without causing double unescaping issues.

- Modify the `pdfUnescape` function to unescape backslashes after unescaping other characters.
- Specifically, change the order of the `replace` calls in the `pdfUnescape` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
