### PR TITLE
Potential fix for code scanning alert no. 164: Client-side cross-site scripting

### DIFF
--- a/src/themes/hexo-theme/source/vendor/notes/notes.html
+++ b/src/themes/hexo-theme/source/vendor/notes/notes.html
@@ -5,6 +5,8 @@
 
 		<title>reveal.js - Slide Notes</title>
 
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.4/purify.min.js"></script>
+
 		<style>
 			body {
 				font-family: Helvetica;
@@ -450,10 +452,11 @@
 						'backgroundTransition=none'
 					].join( '&' );
 
-					var urlSeparator = /\?/.test(data.url) ? '&' : '?';
+					var sanitizedUrl = DOMPurify.sanitize(data.url);
+					var urlSeparator = /\?/.test(sanitizedUrl) ? '&' : '?';
 					var hash = '#/' + data.state.indexh + '/' + data.state.indexv;
-					var currentURL = data.url + urlSeparator + params + '&postMessageEvents=true' + hash;
-					var upcomingURL = data.url + urlSeparator + params + '&controls=false' + hash;
+					var currentURL = sanitizedUrl + urlSeparator + params + '&postMessageEvents=true' + hash;
+					var upcomingURL = sanitizedUrl + urlSeparator + params + '&controls=false' + hash;
 
 					currentSlide = document.createElement( 'iframe' );
 					currentSlide.setAttribute( 'width', 1280 );


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/164](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/164)

To fix the problem, we need to ensure that the `data.url` value is properly sanitized before being used to set the `src` attribute of the iframes. This can be achieved by using a library like DOMPurify to sanitize the URL, ensuring that any potentially harmful content is removed.

1. Import the DOMPurify library.
2. Sanitize the `data.url` value before using it to construct the `currentURL` and `upcomingURL` variables.
3. Replace the original lines where the `data.url` is used with the sanitized version.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
