### PR TITLE
Potential fix for code scanning alert no. 162: Client-side cross-site scripting

### DIFF
--- a/src/themes/hexo-theme/source/vendor/notes/notes.html
+++ b/src/themes/hexo-theme/source/vendor/notes/notes.html
@@ -408,7 +408,7 @@
 							notesValue.innerHTML = marked( data.notes );
 						}
 						else {
-							notesValue.innerHTML = data.notes;
+							notesValue.innerHTML = DOMPurify.sanitize(data.notes);
 						}
 					}
 					else {


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/162](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/162)

To fix the problem, we need to sanitize the `data.notes` value before assigning it to `innerHTML`. One effective way to do this is by using a library like DOMPurify, which is already included in the project (as seen on line 8). DOMPurify can help sanitize the HTML content to prevent XSS attacks.

We will modify the code to use DOMPurify to sanitize `data.notes` before assigning it to `innerHTML`. This change will be made in the `handleStateMessage` function, specifically on line 411.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
