### PR TITLE
Potential fix for code scanning alert no. 123: Double escaping or unescaping

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -6678,7 +6678,7 @@
     };
   
     var pdfUnescape = function pdfUnescape(value) {
-      return value.replace(/\\\\/g, "\\").replace(/\\\(/g, "(").replace(/\\\)/g, ")");
+      return value.replace(/\\\(/g, "(").replace(/\\\)/g, ")").replace(/\\\\/g, "\\");
     };
   
     var f2 = function f2(number) {


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/123](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/123)

To fix the issue, the unescaping of the backslash (`\\`) should be performed last in the `pdfUnescape` function. This ensures that any escape sequences involving backslashes (e.g., `\\(` or `\\)`) are correctly processed before the backslashes themselves are unescaped. This change aligns with the recommendation to unescape the escape character last.

The fix involves reordering the replacements in the `pdfUnescape` function so that the replacement for `\\\\` is performed after the replacements for `\\(` and `\\)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
