### PR TITLE
Potential fix for code scanning alert no. 116: Double escaping or unescaping

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -6676,7 +6676,7 @@
     };
   
     var pdfUnescape = function pdfUnescape(value) {
-      return value.replace(/\\\\/g, "\\").replace(/\\\(/g, "(").replace(/\\\)/g, ")");
+      return value.replace(/\\\(/g, "(").replace(/\\\)/g, ")").replace(/\\\\/g, "\\");
     };
   
     var f2 = function f2(number) {


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/116](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/116)

To fix the issue, the `pdfUnescape` function should unescape the backslash (`\\`) last, after unescaping other characters. This ensures that sequences like `\\\\(` are correctly processed. The fix involves reordering the replacements in the `pdfUnescape` function so that the backslash replacement (`value.replace(/\\\\/g, "\\")`) is performed after the replacements for `\(` and `\)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
