### PR TITLE
Potential fix for code scanning alert no. 179: Client-side URL redirect

### DIFF
--- a/themes/hexo-theme/source/vendor/notes/notes.html
+++ b/themes/hexo-theme/source/vendor/notes/notes.html
@@ -392,6 +392,22 @@
 				}
 
 				/**
+				 * Validates if a URL belongs to a trusted domain.
+				 * @param {string} url - The URL to validate.
+				 * @returns {boolean} True if the URL is trusted, false otherwise.
+				 */
+				function isTrustedDomain(url) {
+					const trustedDomains = ['example.com', 'trustedsite.org'];
+					try {
+						const parsedUrl = new URL(url);
+						return trustedDomains.includes(parsedUrl.hostname);
+					} catch (e) {
+						console.error('Invalid URL:', url);
+						return false;
+					}
+				}
+
+				/**
 				 * Called when the main window sends an updated state.
 				 */
 				function handleStateMessage( data ) {
@@ -453,6 +469,10 @@
 					].join( '&' );
 
 					var sanitizedUrl = DOMPurify.sanitize(data.url);
+					if (!isTrustedDomain(sanitizedUrl)) {
+						console.error('Untrusted URL detected:', sanitizedUrl);
+						return;
+					}
 					var urlSeparator = /\?/.test(sanitizedUrl) ? '&' : '?';
 					var hash = '#/' + data.state.indexh + '/' + data.state.indexv;
 					var currentURL = sanitizedUrl + urlSeparator + params + '&postMessageEvents=true' + hash;


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/179](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/179)

To fix the issue, we need to validate the URL against a whitelist of trusted domains after sanitizing it with `DOMPurify`. This ensures that only URLs from trusted sources are used in the iframe `src` attribute. The fix involves:

1. Defining a whitelist of trusted domains.
2. Adding a validation function to check if the sanitized URL belongs to one of the trusted domains.
3. Rejecting or handling URLs that fail the validation.

The changes will be made in the `setupIframes` function, where the URL is constructed and assigned to the iframe `src` attributes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
