### PR TITLE
Potential fix for code scanning alert no. 191: Incomplete multi-character sanitization

### DIFF
--- a/newsletter-program/package.json
+++ b/newsletter-program/package.json
@@ -26,7 +26,8 @@
     "dotenv": "^16.3.1",
     "js-yaml": "^4.1.0",
     "marked": "^9.1.6",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "striptags": "^3.2.0"
   },
   "devDependencies": {
     "jsdom": "^27.1.0",

--- a/newsletter-program/src/core/rss-monitor.mjs
+++ b/newsletter-program/src/core/rss-monitor.mjs
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
+import striptags from 'striptags';
 
 /**
  * RSS feed monitoring and processing system
@@ -337,7 +338,7 @@ export class RSSMonitor {
       text += `\n`;
       
       if (item.description) {
-        text += `   ${item.description.replace(/<[^>]*>/g, '').substring(0, 200)}...\n`;
+        text += `   ${striptags(item.description).substring(0, 200)}...\n`;
       }
       
       text += `   Read more: ${item.link}\n\n`;


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/191](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/191)

The best way to fix this problem is to use a well-known library for sanitization if possible, since manual regex-based removal is often incomplete. For plain text extraction from HTML, the popular npm package `striptags` can be used, which reliably removes all HTML elements and is well-tested. Alternatively, if introducing a library is not desirable, the regular expression-based tag removal should be applied repeatedly until no tags remain, by looping until the string stabilizes. This avoids leftover fragments from partial replacements.

To implement this fix:
- In file `newsletter-program/src/core/rss-monitor.mjs`, in the `generateTextContent` method (specifically line 340), replace the single call to `.replace(/<[^>]*>/g, '')` with either:
  1. a loop that repeatedly replaces tags until the string stabilizes, *or*
  2. usage of a trusted package such as `striptags` for tag removal.

If using `striptags`, add the import at the top of the file and update line 340. If manually fixing, define a helper function (e.g., `stripHTMLTags`) that loops until done and use that.

Both approaches preserve existing functionality: only tags are removed, and substrings are clipped at 200 characters.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incomplete HTML sanitization by replacing regex-based tag removal with striptags in the RSS monitor. Ensures clean text extraction for newsletter item descriptions while keeping the 200-character clipping.

- **Bug Fixes**
  - Use striptags(item.description) in generateTextContent to reliably remove all HTML.
  - Preserve the 200-character substring and existing output format.

- **Dependencies**
  - Add striptags ^3.2.0 to newsletter-program/package.json.

<sup>Written for commit bf63adc77f7d85c20296a1ab6a69c28aad2c2ae5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

