### PR TITLE
Potential fix for code scanning alert no. 190: Incomplete multi-character sanitization

### DIFF
--- a/newsletter-program/package.json
+++ b/newsletter-program/package.json
@@ -27,7 +27,8 @@
     "js-yaml": "^4.1.0",
     "marked": "^9.1.6",
     "node-fetch": "^3.3.2",
-    "striptags": "^3.2.0"
+    "striptags": "^3.2.0",
+    "html-to-text": "^9.0.5"
   },
   "devDependencies": {
     "jsdom": "^27.1.0",

--- a/newsletter-program/src/core/newsletter-sender.mjs
+++ b/newsletter-program/src/core/newsletter-sender.mjs
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-
+import { htmlToText as convertHtmlToText } from 'html-to-text';
 export class NewsletterSender {
   constructor(dataDir = './data') {
     this.dataDir = dataDir;
@@ -151,17 +151,13 @@ export class NewsletterSender {
   }
 
   htmlToText(html) {
-    return html
-      .replace(/<br\s*\/?>/gi, '\n')
-      .replace(/<\/p>/gi, '\n\n')
-      .replace(/<[^>]*>/g, '')
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/\n\s*\n\s*\n/g, '\n\n')
-      .trim();
+    // Use html-to-text library for robust sanitization
+    return convertHtmlToText(html, {
+      wordwrap: false,
+      selectors: [
+        { selector: 'a', options: { ignoreHref: true } }
+      ]
+    }).trim();
   }
 
   generateUnsubscribeUrl(subscriber) {


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/190](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/190)

The safest and most robust way to address multi-character sanitization vulnerabilities is to use a reputable library designed for HTML-to-text conversion, such as `html-to-text`. This library handles malformed HTML, script tags, and other edge cases.  
If using a library is not feasible, improve the custom sanitizer by repeatedly applying the regular expression for tag removal until no further replacements occur. This ensures that no tag fragments survive through re-introduction after a single replacement pass.  
Modify the `htmlToText` method in `newsletter-program/src/core/newsletter-sender.mjs` on lines 153-165.  
If using a library:  
- Add a `html-to-text` import at the top.  
- Replace the `htmlToText` implementation to use it directly.  
If not, revise the tag-removal step to repeatedly strip tags until none remain. This can be done with a loop applying `.replace(/<[^>]*>/g, '')` until the string is unchanged.  
No other code regions or definitions need modification.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the custom HTML-to-text sanitizer with the html-to-text library to resolve code scanning alert #190 (incomplete multi-character sanitization). Produces safer, cleaner plaintext for newsletter emails.

- **Bug Fixes**
  - Use html-to-text for robust tag stripping and malformed HTML handling; ignore link hrefs, disable word wrap, and trim output.
  - Remove fragile regex/entity decoding that could miss nested or fragmented tags.

- **Dependencies**
  - Add html-to-text ^9.0.5 to newsletter-program/package.json.

<sup>Written for commit 63c4a27364764e993f14e1437f8a968dc0f517bd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

