### PR TITLE
Potential fix for code scanning alert no. 185: Incomplete multi-character sanitization

### DIFF
--- a/newsletter-program/src/core/content-processor.js
+++ b/newsletter-program/src/core/content-processor.js
@@ -42,10 +42,16 @@ export class ContentProcessor {
     const dangerousAttributes = /\s(on\w+|javascript:)[^>]*/gi;
     const dangerousTags = /<(script|iframe|object|embed|form)[^>]*>.*?<\/\1>/gi;
 
-    let sanitized = content
-      .replace(dangerousElements, '')
-      .replace(dangerousTags, '')
-      .replace(dangerousAttributes, '');
+    let sanitized = content;
+    // Repeat replacements until no further dangerous elements/tags/attributes remain
+    let previous;
+    do {
+      previous = sanitized;
+      sanitized = sanitized
+        .replace(dangerousElements, '')
+        .replace(dangerousTags, '')
+        .replace(dangerousAttributes, '');
+    } while (sanitized !== previous);
 
     // Allow only safe HTML tags
     const allowedTags = ['p', 'br', 'strong', 'em', 'u', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li', 'a', 'img'];


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/185](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/185)

To fix the incomplete multi-character sanitization, each replacement targeting dangerous HTML tags (like `<script>`, `<iframe>`, etc.) should be applied repeatedly until no more matches are found—just as in the precaution recommended in the background. This can be done by looping over the replacements until the input does not change. For each dangerous pattern, apply replacement in a loop. These fixes should be implemented in the `sanitizeContent` method in `newsletter-program/src/core/content-processor.js`, specifically starting from line 45.

No external library is strictly required, but using such a library (like `sanitize-html`) is preferable for robust protection. However, if only the shown code can be edited and adding a dependency is not viable, the repeated replacement solution should be used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code scanning alert #185 by looping sanitization in sanitizeContent until no dangerous elements, tags, or attributes remain. Closes the multi-character sanitization gap to block nested or split patterns like <script>, <iframe>, and on* handlers.

<sup>Written for commit 3310ea98f69c544fa0a90bbb6ab39047ca6e480b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

