### PR TITLE
Potential fix for code scanning alert no. 180: Bad HTML filtering regexp

### DIFF
--- a/newsletter-program/package.json
+++ b/newsletter-program/package.json
@@ -27,8 +27,10 @@
     "js-yaml": "^4.1.0",
     "marked": "^9.1.6",
     "node-fetch": "^3.3.2",
-    "striptags": "^3.2.0","aes256":"1.1.0",
-    "html-to-text": "^9.0.5"
+    "striptags": "^3.2.0",
+    "aes256": "1.1.0",
+    "html-to-text": "^9.0.5",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "cross-env": "^10.1.0",


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/180](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/180)

The best way to fix the problem is to use a robust HTML sanitization library rather than attempting manual filtering by regular expression. For JavaScript/Node.js projects, `sanitize-html` is a widely used, well-tested library that allows configuration of allowed tags/attributes and will safely remove dangerous elements such as script tags, regardless of quirks in HTML parsing by browsers.

You should:
- Replace the custom regex-based logic in `sanitizeContent` with a call to `sanitize-html`.
- Configure `sanitize-html` to allow only the safe HTML tags already listed in `allowedTags` (p, br, strong, em, etc.).
- Configure attributes for `a` and `img` as needed.
- Remove lines 41-73, which manually handle dangerous elements/tags/attributes.
- Add an import for `sanitize-html` at the top of the file.

Only the file `newsletter-program/src/core/content-processor.js` is affected. Make sure to add the `sanitize-html` import at the top, and update the `sanitizeContent` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace fragile regex-based HTML sanitization with sanitize-html to fix the “Bad HTML filtering regexp” alert and prevent XSS. This secures newsletter content by allowing only safe tags, attributes, and URL schemes.

- **Bug Fixes**
  - Switched sanitizeContent to use sanitize-html with a strict allowlist for tags and attributes (including a and img).
  - Restricted URL schemes (http, https, mailto, data for img) and removed custom filtering logic.

- **Dependencies**
  - Added sanitize-html ^2.17.0 to package.json.

<sup>Written for commit 2b6eb69b1aa42e274ccad8153385f4b63e6285db. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

