### PR TITLE
Potential fix for code scanning alert no. 160: DOM text reinterpreted as HTML

### DIFF
--- a/src/situationItem.vue
+++ b/src/situationItem.vue
@@ -14,7 +14,8 @@ Object.keys(document.getElementsByTagName("a")).map((ite)=>{
     //console.log(item.parentElement)
     log.info(item.href.includes("situation"))
 
-      item.href=window.location.href+"situation/"+item.textContent.split("/")[item.textContent.split("/").length-1]
+      const safeText = encodeURIComponent(item.textContent.split("/")[item.textContent.split("/").length-1]);
+      item.href = window.location.href + "situation/" + safeText;
     item.href=item.href.replace("situationsituation",'situation').replace("projetprojet",'projet')
     
     log.info(item.href)


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/160](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/160)

To fix the problem, we should ensure that any text extracted from the DOM and re-used in building a URL or HTML should be properly sanitized or encoded before being inserted. In this context, since we're creating a URL, the safest fix is to encode any value derived from `item.textContent` using `encodeURIComponent` before inserting it into the href. This prevents special URL/meta-characters and scripts from being interpreted in an unsafe manner.

**Edits required:**
- Change line 17 of `src/situationItem.vue` to ensure that when splitting and using `item.textContent`, any value derived from it is properly encoded before being put in the URL.
- The fix should use native JavaScript `encodeURIComponent` for encoding the portion derived from `item.textContent`, at the point where it's inserted into the URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encodes the DOM-derived URL segment in src/situationItem.vue using encodeURIComponent to fix code scanning alert #160 and prevent unsafe hrefs. This ensures anchor links use sanitized text so special characters can’t be interpreted as HTML or scripts.

<sup>Written for commit 6811c7d79932d7cc9f7373529a9b183fae472abb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

