### PR TITLE
Potential fix for code scanning alert no. 159: DOM text reinterpreted as HTML

### DIFF
--- a/src/projetItem.vue
+++ b/src/projetItem.vue
@@ -14,7 +14,8 @@ Object.keys(document.getElementsByTagName("a")).map((ite)=>{
     //console.log(item.parentElement)
     log.info(item.href.includes("projet"))
 
-      item.href=window.location.href+"projet/"+item.textContent.split("/")[item.textContent.split("/").length-1]
+      const lastSegment = item.textContent.split("/")[item.textContent.split("/").length-1];
+      item.href = window.location.href + "projet/" + encodeURIComponent(lastSegment);
     item.href=item.href.replace("situationsituation",'situation').replace("projetprojet",'projet')
     
     log.info(item.href)


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/159](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/159)

To fix the vulnerability, we should escape or validate the value of `item.textContent` before using it to construct the `href`. The safest approach is to ensure the value is only used as a path segment in a URL, and meta-characters (like `<`, `>`, `"`, `'`, and any non-standard URL characters) are properly percent-encoded. To do this, pass the dynamic segment through `encodeURIComponent`, which safely escapes such characters. This preserves the original functionality (building the URL based on the slot's text), but ensures attackers cannot inject malicious content via this field.

Code to change:  
In the setup script (around line 17 of `src/projetItem.vue`), update the string concatenation so that the dynamic portion (the last segment extracted from `item.textContent.split("/")`) is passed through `encodeURIComponent` before being appended to the URL.

No new imports are required as `encodeURIComponent` is a standard global JavaScript function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitized dynamic href generation by percent-encoding the last segment from DOM text to resolve code scanning alert 159. This prevents HTML/script injection while keeping project links working.

- **Bug Fixes**
  - In src/projetItem.vue, encode the last textContent segment with encodeURIComponent before building href.
  - Prevents DOM text from being reinterpreted as HTML (XSS) in project links.

<sup>Written for commit 07a2ca3079866a2b02d06027308c5b19899224d5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

