### PR TITLE
Potential fix for code scanning alert no. 129: DOM text reinterpreted as HTML

### DIFF
--- a/docs/assets/situation-Bk8jLSj1.js
+++ b/docs/assets/situation-Bk8jLSj1.js
@@ -14,7 +14,8 @@ const _sfc_main$1 = {
         console.log(item.href);
         if (item.id) {
           log.info(item.href.includes("situation"));
-          item.href = window.location.href + "situation/" + item.textContent.split("/")[item.textContent.split("/").length - 1];
+          const safeSegment = encodeURIComponent(item.textContent.split("/")[item.textContent.split("/").length - 1]);
+          item.href = window.location.href + "situation/" + safeSegment;
           item.href = item.href.replace("situationsituation", "situation").replace("projetprojet", "projet");
           log.info(item.href);
         }


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/129](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/129)

To fix this issue, sanitize the value of `item.textContent` before including it in the constructed `href`. A common approach is to URL-encode the last segment derived from `item.textContent`, ensuring that any meta-characters or potentially unsafe input is safely encoded, thereby preventing injection. This should be done only for the dynamic part of the URL that's derived from `item.textContent.split("/").pop()`. 

The change should be local to line 17 in docs/assets/situation-Bk8jLSj1.js. Use `encodeURIComponent` to encode the value from `item.textContent.split("/")[item.textContent.split("/").length - 1]` before appending it to the URL. No new dependencies are required; `encodeURIComponent` is a standard built-in JavaScript function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encode the last segment from item.textContent with encodeURIComponent when building item.href to prevent DOM text being reinterpreted as HTML. Addresses security code scanning alert #129; change is localized to docs/assets/situation-Bk8jLSj1.js with no dependency updates.

<sup>Written for commit fc3e23c7ecfebd680905907b567405d853c214fb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

