### PR TITLE
Fix: ESM import of CommonJS modules in rss-monitor-action.mjs

### DIFF
--- a/.github/scripts/rss-monitor-action.mjs
+++ b/.github/scripts/rss-monitor-action.mjs
@@ -16,9 +16,9 @@ const __dirname = path.dirname(__filename);
 const newsletterProgramPath = path.join(__dirname, '..', '..', 'newsletter-program');
 process.chdir(newsletterProgramPath);
 
-import { RSSMonitor } from '../../newsletter-program/src/core/rss-monitor.js';
-import { NewsletterSender } from '../../newsletter-program/src/core/newsletter-sender.js';
-import { SubscriberFileManager } from '../../newsletter-program/src/core/subscriber-file-manager.js';
+import RSSMonitorModule from '../../newsletter-program/src/core/rss-monitor.js';
+import NewsletterSenderModule from '../../newsletter-program/src/core/newsletter-sender.js';
+import SubscriberFileManagerModule from '../../newsletter-program/src/core/subscriber-file-manager.js';
 
 class GitHubActionsRSSMonitor {
   constructor() {
@@ -26,9 +26,9 @@ class GitHubActionsRSSMonitor {
     this.dataPath = path.join(__dirname, '..','data');
     //console.log(this.dataPath)
     // Initialize components with repository data path
-    this.rssMonitor = new RSSMonitor(this.dataPath);
-    this.newsletterSender = new NewsletterSender();
-    this.subscriberManager = new SubscriberFileManager();
+    this.rssMonitor = new RSSMonitorModule.RSSMonitor(this.dataPath);
+    this.newsletterSender = new NewsletterSenderModule.NewsletterSender();
+    this.subscriberManager = new SubscriberFileManagerModule.SubscriberFileManager();
     
     // GitHub Actions environment
     this.isGitHubActions = process.env.GITHUB_ACTIONS === 'true';
@@ -341,7 +341,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         console.log('  stats     - Show RSS and subscriber statistics');
         console.log('  validate  - Validate RSS and subscriber configuration');
         process.exit(1);
-    }
+  }
   } catch (error) {
    // console.error('❌ Error:', error.message);
     process.exit(1);


### PR DESCRIPTION
This PR fixes the SyntaxError: Named export '...' not found when an ESM script attempts to import CommonJS modules. It updates the import statements in .github/scripts/rss-monitor-action.mjs to use default imports for the CommonJS modules (RSSMonitor, NewsletterSender, SubscriberFileManager) and then accesses the classes as properties of the imported module objects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ESM/CommonJS import mismatch in rss-monitor-action.mjs to stop “Named export not found” errors in GitHub Actions. The script now imports CommonJS modules as default and accesses classes via module properties.

- **Bug Fixes**
  - Replaced named imports with default imports for RSSMonitor, NewsletterSender, and SubscriberFileManager.
  - Instantiated classes via module properties (e.g., new RSSMonitorModule.RSSMonitor()).

<sup>Written for commit 88eef12b3e8ba377edcfb704ddb27f94a5c44f84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

