### PR TITLE
Fix: Syntax error in rss-monitor.js HTML generation

### DIFF
--- a/newsletter-program/src/core/rss-monitor.js
+++ b/newsletter-program/src/core/rss-monitor.js
@@ -287,8 +287,7 @@ class RSSMonitor {
    * Generate HTML content for newsletter
    */
   async generateHTMLContent(feed, items) {
-    const summaryContent = await getGeminiLeaksSummary(process.env.GEMINI_API_KEY, items.map(e => e.content).join("
-"));
+    const summaryContent = await getGeminiLeaksSummary(process.env.GEMINI_API_KEY, items.map(e => e.content).join("\n"));
     
     let html = `
     <h1>📰 ${feed.title}</h1>


### PR DESCRIPTION
This PR fixes a SyntaxError: Invalid or unexpected token in newsletter-program/src/core/rss-monitor.js caused by a malformed string literal for the .join() method. It changes 'join(\
\n\)' to 'join(\\\\\n\)' to ensure correct string termination.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a SyntaxError in rss-monitor.js by replacing a malformed multiline string in items.map(...).join() with a proper "\n" delimiter. This restores newsletter HTML generation and ensures getGeminiLeaksSummary receives correctly joined content.

<sup>Written for commit ad698356b5bd488f82b2fa886cd7dc924ce0ceba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

