### PR TITLE
Potential fix for code scanning alert no. 128: DOM text reinterpreted as HTML

### DIFF
--- a/docs/assets/projet-BmppqA-P.js
+++ b/docs/assets/projet-BmppqA-P.js
@@ -14,7 +14,10 @@ const _sfc_main$1 = {
         console.log(item.href);
         if (item.id) {
           log.info(item.href.includes("projet"));
-          item.href = window.location.href + "projet/" + item.textContent.split("/")[item.textContent.split("/").length - 1];
+          const text = String(item.textContent || "");
+          const rawSegment = text.split("/")[text.split("/").length - 1].trim();
+          const safeSegment = /^[a-zA-Z0-9_-]+$/.test(rawSegment) ? rawSegment : "";
+          item.href = window.location.href + "projet/" + encodeURIComponent(safeSegment);
           item.href = item.href.replace("situationsituation", "situation").replace("projetprojet", "projet");
           log.info(item.href);
         }


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/128](https://github.com/thomas-iniguez-visioli/portfolio/security/code-scanning/128)

Best fix: treat `item.textContent` as untrusted, extract only the intended path segment, validate it against a strict allowlist, and URL-encode before composing the destination URL.

In `docs/assets/projet-BmppqA-P.js` around line 17, replace direct usage of `item.textContent.split("/")...` with:
- a safe string normalization (`String(item.textContent || "")`);
- extraction of the last segment;
- strict validation (for example alphanumerics, `_`, `-`);
- `encodeURIComponent` before concatenation.

This preserves existing functionality (building `/projet/<name>` links) while preventing reinterpretation of unsafe characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code scanning alert 128 by sanitizing DOM text before building `projet` links to prevent HTML reinterpretation and potential injection. Preserves existing `/projet/<name>` behavior.

- **Bug Fixes**
  - In `docs/assets/projet-BmppqA-P.js`, treat `item.textContent` as untrusted.
  - Coerce to string, trim, and take the last segment after `/`.
  - Validate with `/^[a-zA-Z0-9_-]+$/`; fallback to empty if invalid.
  - URL-encode with `encodeURIComponent` before concatenating into the href.

<sup>Written for commit afe537ad6845a317e51e703d27b1e2993a138f0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

