### PR TITLE
fix: corriger la détection des flux RSS et dates de publication

### DIFF
--- a/newsletter-program/package.json
+++ b/newsletter-program/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newsletter-program",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Standalone newsletter management program with RSS monitoring and encryption",
   "main": "src/index.js",
   "bin": {

--- a/newsletter-program/src/core/rss-monitor.js
+++ b/newsletter-program/src/core/rss-monitor.js
@@ -431,7 +431,7 @@ ${feed.url}`;
 
   parseRSSItems(xmlContent) {
     const items = [];
-    const isAtom = true;
+    const isAtom = xmlContent.includes('<feed') || xmlContent.includes('<entry');
     
     // Improved item extraction to handle nested tags or issues with greedy matching
     const tag = isAtom ? 'entry' : 'item';
@@ -472,7 +472,7 @@ ${feed.url}`;
       const title = extractCDATA(extractTag('title', isAtom));
       const link = extractTag('link', isAtom);
       const description = extractCDATA(extractTag(isAtom ? 'summary' : 'description', isAtom));
-      const pubDate =  extractTag('updated', isAtom);
+      const pubDate = extractTag(isAtom ? 'updated' : 'pubDate', isAtom) || extractTag('dc:date', isAtom);
       const author = extractTag('author', isAtom) || extractTag('dc:creator', isAtom);
       const guid = extractTag(isAtom ? 'id' : 'guid', isAtom) || link;
       const content = extractCDATA(extractTag(isAtom ? 'content' : 'content:encoded', isAtom)) || extractCDATA(extractTag('content'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-site",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "build": "npm run optimize && npm run clean && npx hexo deploy",


### PR DESCRIPTION
Cette PR résout le problème de détection des nouveaux posts sur les flux RSS non-Atom en rendant dynamique la détection du format de flux et de la date de publication.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix dynamic detection of RSS vs Atom feeds and publish dates to stop missing new posts on non-Atom feeds. This makes the monitor parse items and dates reliably across RSS/Atom variants.

- **Bug Fixes**
  - Detect feed type from XML (`<feed>`/`<entry>`) instead of hardcoding Atom.
  - Parse publish date by format: Atom `updated`, RSS `pubDate`, fallback `dc:date`.

- **Dependencies**
  - Bump `newsletter-program` to `1.0.2`.
  - Bump `hexo-site` to `0.0.2`.

<sup>Written for commit 13d5e33acb09685eadd3c67488d3779706819afe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thomas-iniguez-visioli/portfolio/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

