### PR TITLE
fix: détection des mises à jour RSS et désactivation de l'anti-adblock

### DIFF
--- a/newsletter-program/package.json
+++ b/newsletter-program/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newsletter-program",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Standalone newsletter management program with RSS monitoring and encryption",
   "main": "src/index.js",
   "bin": {

--- a/newsletter-program/src/core/rss-monitor.js
+++ b/newsletter-program/src/core/rss-monitor.js
@@ -224,6 +224,7 @@ class RSSMonitor {
     const feedCache = cache.items[feedId] || [];
     const newItems = this.filterNewItems(items, feedCache);
 
+    const updatedGuids = new Set(newItems.map(item => item.guid));
     cache.items[feedId] = [
       ...newItems.map(item => ({
         guid: item.guid,
@@ -232,7 +233,7 @@ class RSSMonitor {
         processedAt: new Date().toISOString(),
         content: item.content
       })),
-      ...feedCache
+      ...feedCache.filter(item => !updatedGuids.has(item.guid))
     ].slice(0, 2000);
 
     cache.lastUpdated = new Date().toISOString();
@@ -494,8 +495,21 @@ ${feed.url}`;
   }
 
   filterNewItems(items, cachedItems) {
-    const cachedGuids = new Set(cachedItems.map(item => item.guid));
-    return items.filter(item => !cachedGuids.has(item.guid));
+    const newOrUpdated = [];
+    for (const item of items) {
+      const cachedItem = cachedItems.find(c => c.guid === item.guid);
+      if (!cachedItem) {
+        newOrUpdated.push(item);
+      } else {
+        const isDateNewer = item.published && cachedItem.published && new Date(item.published) > new Date(cachedItem.published);
+        const isContentDifferent = (item.content !== undefined && cachedItem.content !== undefined && item.content !== cachedItem.content) || 
+                                   (item.title !== undefined && cachedItem.title !== undefined && item.title !== cachedItem.title);
+        if (isDateNewer || isContentDifferent) {
+          newOrUpdated.push(item);
+        }
+      }
+    }
+    return newOrUpdated;
   }
 
   loadFeeds() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-site",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "private": true,
   "scripts": {
     "build": "npm run optimize && npm run clean && npx hexo deploy",

--- a/themes/matrix-flow/layout/layout.ejs
+++ b/themes/matrix-flow/layout/layout.ejs
@@ -23,7 +23,7 @@
     "closePopup": true,
     "showIcon": true,
     "iconPosition": "TopRight",
-  "adblocker": true,
+  "adblocker": false,
     "DenyAllCta" : true,
     "AcceptAllCta" : true,
     "highPrivacy": true,


### PR DESCRIPTION
Cette PR corrige le filtrage RSS afin de détecter les articles mis à jour (lorsque le titre, le contenu ou la date de publication changent pour un même guid) et désactive la détection anti-adblock de tarteaucitron.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix RSS monitoring to catch article updates when the same `guid` changes (title, content, or published date) and replace the old cache entry. Turned off tarteaucitron anti-adblock (`adblocker: false`) to avoid false blocks; bumped to `newsletter-program@1.0.4` and `hexo-site@0.0.4`.

<sup>Written for commit f1e08bb78fe19d13897358959b574b0181d3d7bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thomas-iniguez-visioli/portfolio/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

